### PR TITLE
Fix tsv/csv output losing row separators between matches

### DIFF
--- a/src/Models/Content/ResultContent/ResultContentCSVModel.ts
+++ b/src/Models/Content/ResultContent/ResultContentCSVModel.ts
@@ -1,3 +1,4 @@
+import { Common } from "../../../Commons/Common";
 import { ResultContentModel } from "./ResultContentModel";
 
 export class ResultContentCSVModel extends ResultContentModel {
@@ -19,6 +20,10 @@ export class ResultContentCSVModel extends ResultContentModel {
         if (!this.hasOutputTitle()) {
             contents.shift();
         }
-        return contents.join(this.SEPARATOR);
+        // A trailing line break is required: ResultFileModel positions each insert at
+        // Position(document.lineCount, 0), which only lands on a fresh line when the
+        // previous insert actually ended one. Without it, rows are pasted together
+        // with no separator at all.
+        return contents.join(this.SEPARATOR) + Common.LINE_BREAK;
     }
 }

--- a/src/Models/Content/ResultContent/ResultContentModel.ts
+++ b/src/Models/Content/ResultContent/ResultContentModel.ts
@@ -115,6 +115,44 @@ export class ResultContentModel extends BaseModel {
     }
 
     /**
+     * Same as calling addLine() once per entry, but writes the whole batch with a single
+     * editor edit instead of one edit per line. Returns, for each entry in the same order,
+     * the document line it landed on plus its searchable-text offset (for decoration ranges)
+     * so callers never need to read the document back to find out where their match ended up.
+     */
+    public async addLines(entries: Array<{ filePath: string; lineNumber: string; line: string }>)
+        : Promise<Array<{ documentLineNumber: number; extracted: { text: string; offset: number } | null }>> {
+
+        if (entries.length === 0) {
+            return [];
+        }
+
+        // Build every entry's formatted content up front (pure string work, no editor round-trip).
+        const formattedContents = entries.map(e =>
+            this.getFormattedContent([this._grepConditionText, e.filePath, e.lineNumber, e.line])
+        );
+
+        const firstLineNumber = await this.insertAndStackContentBlock(formattedContents);
+
+        // extractContentAndOffset expects a single document line (no trailing break), the same
+        // shape LineMatcher.splitIntoNumberedLines used to hand it back when this ran off a
+        // full-document rescan. Strip the trailing Common.LINE_BREAK that getFormattedContent
+        // adds before handing each chunk over.
+        const results = formattedContents.map((content, i) => {
+            const lineText = content.endsWith(Common.LINE_BREAK)
+                ? content.slice(0, -Common.LINE_BREAK.length)
+                : content;
+            return {
+                documentLineNumber: firstLineNumber + i,
+                extracted: this.extractContentAndOffset(lineText)
+            };
+        });
+
+        this._lineNumberOfCursor = firstLineNumber + formattedContents.length - 1;
+        return results;
+    }
+
+    /**
      * Called once after grepping finishes (success or cancellation). No-op by default;
      * overridden by formats that need to close a wrapping structure (e.g. json's closing "]").
      */
@@ -131,6 +169,22 @@ export class ResultContentModel extends BaseModel {
 
         // return inserted line number
         return insertedLineNumber;
+    }
+
+    /**
+     * Batched counterpart of insertAndStackContent(): writes several already-formatted chunks
+     * with one editor edit and returns the document line of the first chunk.
+     */
+    protected async insertAndStackContentBlock(formattedContents: string[]): Promise<number> {
+        const combinedContent = formattedContents.join('');
+        const firstLineNumber = await this._resultFileModel.insertTextBlock(combinedContent);
+
+        formattedContents.forEach((content, i) => {
+            const contentInfo = this._contentFactory.retrieve(content, firstLineNumber + i);
+            this.contentInformations.push(contentInfo);
+        });
+
+        return firstLineNumber;
     }
     //------ Operation  of ResultFile (Interact with Service) ------
 

--- a/src/Models/Content/ResultContent/ResultContentTSVModel.ts
+++ b/src/Models/Content/ResultContent/ResultContentTSVModel.ts
@@ -2,11 +2,4 @@ import { ResultContentCSVModel } from "./ResultContentCSVModel";
 
 export class ResultContentTSVModel extends ResultContentCSVModel {
     protected _separator = "\t";
-
-    protected getFormattedContent(contents: string[]) {
-        if (!this.hasOutputTitle()) {
-            contents.shift();
-        }
-        return contents.join(this.SEPARATOR);
-    }
 }

--- a/src/Models/File/ResultFileModel.ts
+++ b/src/Models/File/ResultFileModel.ts
@@ -98,13 +98,33 @@ export class ResultFileModel extends FileModel {
         });
 
         // return inserted line number
-        const lineCount = this.getLastLine(editor); 
+        const lineCount = this.getLastLine(editor);
         return lineCount === 0 ? 0 : lineCount - 1;
     }
 
-    public getText(): string {
+    /**
+     * Insert a block made of several newline-terminated chunks (e.g. several grep matches
+     * concatenated together) with a single editor edit, instead of one edit per chunk.
+     * Each editor.edit() call is a round-trip to the main/renderer process, so issuing one per
+     * matched line makes grepping extremely sensitive to whatever else VS Code's UI thread is
+     * doing (typing, clicking, etc.); batching multiple chunks into one edit avoids that.
+     *
+     * Returns the 0-indexed document line of the *first* chunk. Because every previous insert
+     * here always ends with a line break, the document's current last line is empty and gets
+     * filled by the first chunk, so that starting line is (current line count - 1); each
+     * subsequent chunk then lands on the following line.
+     */
+    public async insertTextBlock(content: string): Promise<number> {
         const editor = this._editor!;
-        return editor.document.getText();
+        const startLine = Math.max(this.getLastLine(editor) - 1, 0);
+
+        if (content === "") { return startLine; }
+
+        await editor.edit(editBuilder => {
+            editBuilder.insert(this.getPosition(editor), content);
+        });
+
+        return startLine;
     }
 
 }

--- a/src/Models/SearchWordConfiguration.ts
+++ b/src/Models/SearchWordConfiguration.ts
@@ -69,7 +69,11 @@ export class SearchWordConfiguration {
     public getRegExp(isGlobal?: boolean): RegExp {
 
         if (isGlobal) {
-            return this._regExp = new RegExp(this.SearchWord, this.RegExpOptions + 'g');
+            // Intentionally not cached into this._regExp: that field backs the non-global
+            // getRegExp() calls below, and a global-flagged RegExp is stateful (its lastIndex
+            // advances on every exec/test). Caching it there would let a later non-global call
+            // silently receive a stateful regex and start missing matches depending on call order.
+            return new RegExp(this.SearchWord, this.RegExpOptions + 'g');
         }
 
         if (this._regExp === null) {

--- a/src/Services/GrepService.ts
+++ b/src/Services/GrepService.ts
@@ -14,6 +14,17 @@ import { LineMatcher } from './LineMatcher';
 
 export class GrepService implements IService {
 
+    // Matches are buffered and flushed together instead of one editor.edit()/setDecorations()
+    // call per matched line. Each of those calls is a round-trip to VS Code's main/renderer
+    // process, so doing one per line makes grepping progress hostage to whatever else the UI
+    // thread is busy with (typing, clicking, scrolling, ...) - operating VS Code while a grep
+    // is running could stall the whole search until the UI went idle again. Batching cuts the
+    // number of round-trips by ~BATCH_SIZE and also avoids doing the write in lock-step with
+    // the UI thread.
+    protected static readonly BATCH_SIZE = 40;
+    protected pendingMatches: NumberedFileLine[] = [];
+    protected allRanges: vscode.Range[] = [];
+
     protected searchConfig = new SearchWordConfiguration();
     protected optionalService: AbsOptionalService;
     protected directoryWalker = new DirectoryWalker();
@@ -88,6 +99,8 @@ export class GrepService implements IService {
         // Do grep and write its found result.
         try {
             await this.directoryWalker.walk(Common.BASE_DIR, [this.resultFile.FileNameWithExtension], r => this.findWordInAFile(r));
+            // Flush whatever is left in the buffer (fewer than BATCH_SIZE matches).
+            await this.flushPendingMatches();
             // Notify finish
             vscode.window.showInformationMessage(Message.MESSAGE_FINISH);
         } catch (e) {
@@ -103,33 +116,43 @@ export class GrepService implements IService {
 
     protected async findWordInAFile(r: NumberedFileLine[]) {
         const content = r.filter(v => LineMatcher.isContainSearchWord(this.searchConfig.getRegExp(), v.lineText));
-        for (const v of content) {
-            await this.resultContent.addLine(v.filePath, v.lineNumber.toString(), v.lineText)
-            .then(async () => this.optionalService
-                .setParam(await this.findWordsWithRange())
-                .doService())
-            .then(() => this.timeKeeper.throwErrorIfCancelled());
+        this.pendingMatches.push(...content);
+
+        if (this.pendingMatches.length >= GrepService.BATCH_SIZE) {
+            await this.flushPendingMatches();
         }
     }
 
-    public async findWordsWithRange(): Promise<Array<vscode.Range>> {
-        const ranges: vscode.Range[] = [];
+    /**
+     * Write every buffered match with a single editor edit, update decorations once for the
+     * whole batch, then check for cancellation. Called every BATCH_SIZE matches and once more
+     * after the walk finishes to flush the remainder.
+     */
+    protected async flushPendingMatches() {
+        if (this.pendingMatches.length === 0) {
+            return;
+        }
 
-        const lines = LineMatcher.splitIntoNumberedLines(this.resultFile.getText(), this.resultContent.lineNumberOfContentStart);
-        for (const foundWordInfo of lines) {
-            const extracted = this.resultContent.extractContentAndOffset(foundWordInfo.lineText);
+        const batch = this.pendingMatches;
+        this.pendingMatches = [];
+
+        const entries = batch.map(v => ({ filePath: v.filePath, lineNumber: v.lineNumber.toString(), line: v.lineText }));
+        const results = await this.resultContent.addLines(entries);
+
+        const regExp = this.searchConfig.getRegExp(true);
+        for (const { documentLineNumber, extracted } of results) {
             if (extracted === null) {
                 continue;
             }
-
-            const lineNumber = (foundWordInfo.lineNumber - 1);
-            const range = this.getFindWordRange(this.searchConfig.getRegExp(true), extracted.text, lineNumber, extracted.offset);
+            const range = this.getFindWordRange(regExp, extracted.text, documentLineNumber, extracted.offset);
             if (range !== null) {
-                ranges.push(range);
+                this.allRanges.push(range);
             }
         }
 
-        return ranges;
+        this.optionalService.setParam(this.allRanges).doService();
+
+        this.timeKeeper.throwErrorIfCancelled();
     }
 
 

--- a/src/test/test-resources/expected/grep2File.g2f.csv
+++ b/src/test/test-resources/expected/grep2File.g2f.csv
@@ -1,4 +1,5 @@
-GrepConf,FilePath,lineNumber,TextLineSearch Dir: c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input | Search Word: lo | RegExpMode: OFF,c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input\dir1\dir1-1\fileC.txt,2,"Lorem ipsum dolor sit amet, 
+GrepConf,FilePath,lineNumber,TextLine
+Search Dir: c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input | Search Word: lo | RegExpMode: OFF,c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input\dir1\dir1-1\fileC.txt,2,"Lorem ipsum dolor sit amet, 
 Search Dir: c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input | Search Word: lo | RegExpMode: OFF,c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input\dir1\dir1-1\fileC.txt,5,labore et dolore magna aliqua. 
 Search Dir: c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input | Search Word: lo | RegExpMode: OFF,c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input\dir1\dir1-1\fileC.txt,8,ea commodo consequat. Duis aute irure dolor in reprehenderit 
 Search Dir: c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input | Search Word: lo | RegExpMode: OFF,c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input\dir1\dir1-1\fileC.txt,9,in voluptate velit esse cillum dolore eu fugiat nulla pariatur. 

--- a/src/test/test-resources/expected/grep2File.g2f.tsv
+++ b/src/test/test-resources/expected/grep2File.g2f.tsv
@@ -1,4 +1,5 @@
-GrepConf	FilePath	lineNumber	TextLineSearch Dir: c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input | Search Word: lo | RegExpMode: OFF	c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input\dir1\dir1-1\fileC.txt	2	"Lorem ipsum dolor sit amet, 
+GrepConf	FilePath	lineNumber	TextLine
+Search Dir: c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input | Search Word: lo | RegExpMode: OFF	c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input\dir1\dir1-1\fileC.txt	2	"Lorem ipsum dolor sit amet, 
 Search Dir: c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input | Search Word: lo | RegExpMode: OFF	c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input\dir1\dir1-1\fileC.txt	5	labore et dolore magna aliqua. 
 Search Dir: c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input | Search Word: lo | RegExpMode: OFF	c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input\dir1\dir1-1\fileC.txt	8	ea commodo consequat. Duis aute irure dolor in reprehenderit 
 Search Dir: c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input | Search Word: lo | RegExpMode: OFF	c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input\dir1\dir1-1\fileC.txt	9	in voluptate velit esse cillum dolore eu fugiat nulla pariatur. 

--- a/src/test/test-resources/expected/regexp_grep2File.g2f.csv
+++ b/src/test/test-resources/expected/regexp_grep2File.g2f.csv
@@ -1,4 +1,5 @@
-GrepConf,FilePath,lineNumber,TextLineSearch Dir: c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input | Search Word: lo.*it | RegExpMode: ON,c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input\dir1\dir1-1\fileC.txt,2,"Lorem ipsum dolor sit amet, 
+GrepConf,FilePath,lineNumber,TextLine
+Search Dir: c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input | Search Word: lo.*it | RegExpMode: ON,c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input\dir1\dir1-1\fileC.txt,2,"Lorem ipsum dolor sit amet, 
 Search Dir: c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input | Search Word: lo.*it | RegExpMode: ON,c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input\dir1\dir1-1\fileC.txt,8,ea commodo consequat. Duis aute irure dolor in reprehenderit 
 Search Dir: c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input | Search Word: lo.*it | RegExpMode: ON,c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input\dir1\fileB.txt,2,"Lorem ipsum dolor sit amet, 
 Search Dir: c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input | Search Word: lo.*it | RegExpMode: ON,c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input\dir1\fileB.txt,8,ea commodo consequat. Duis aute irure dolor in reprehenderit 

--- a/src/test/test-resources/expected/regexp_grep2File.g2f.tsv
+++ b/src/test/test-resources/expected/regexp_grep2File.g2f.tsv
@@ -1,4 +1,5 @@
-GrepConf	FilePath	lineNumber	TextLineSearch Dir: c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input | Search Word: lo.*it | RegExpMode: ON	c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input\dir1\dir1-1\fileC.txt	2	"Lorem ipsum dolor sit amet, 
+GrepConf	FilePath	lineNumber	TextLine
+Search Dir: c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input | Search Word: lo.*it | RegExpMode: ON	c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input\dir1\dir1-1\fileC.txt	2	"Lorem ipsum dolor sit amet, 
 Search Dir: c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input | Search Word: lo.*it | RegExpMode: ON	c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input\dir1\dir1-1\fileC.txt	8	ea commodo consequat. Duis aute irure dolor in reprehenderit 
 Search Dir: c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input | Search Word: lo.*it | RegExpMode: ON	c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input\dir1\fileB.txt	2	"Lorem ipsum dolor sit amet, 
 Search Dir: c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input | Search Word: lo.*it | RegExpMode: ON	c:\work\repo\vs_extensions\GrepExtension\src\test\test-resources\input\dir1\fileB.txt	8	ea commodo consequat. Duis aute irure dolor in reprehenderit 

--- a/src/test/unit/ResultContentCSVModel.test.ts
+++ b/src/test/unit/ResultContentCSVModel.test.ts
@@ -20,14 +20,14 @@ suite('ResultContentCSVModel', () => {
 		const dao = new FakeDao({ outputTitle: true });
 		const model = new ResultContentCSVModel(dao, new ResultFileModel(dao));
 
-		assert.strictEqual(model.ColumnTitle, 'GrepConf,FilePath,lineNumber,TextLine');
+		assert.strictEqual(model.ColumnTitle, 'GrepConf,FilePath,lineNumber,TextLine\n');
 	});
 
 	test('ColumnTitle drops the GrepConf column when outputTitle is off', () => {
 		const dao = new FakeDao({ outputTitle: false });
 		const model = new ResultContentCSVModel(dao, new ResultFileModel(dao));
 
-		assert.strictEqual(model.ColumnTitle, 'FilePath,lineNumber,TextLine');
+		assert.strictEqual(model.ColumnTitle, 'FilePath,lineNumber,TextLine\n');
 	});
 
 	test('getContentInOneLine embeds the grep condition (" | " joined) into every row when outputTitle is on', () => {
@@ -38,7 +38,7 @@ suite('ResultContentCSVModel', () => {
 		const line = model.getContentInOneLine('c:\\some\\file.csv', '3', 'matched text');
 		assert.strictEqual(
 			line,
-			'Search Dir: C:\\base | Search Word: lo | RegExpMode: OFF,c:\\some\\file.csv,3,matched text'
+			'Search Dir: C:\\base | Search Word: lo | RegExpMode: OFF,c:\\some\\file.csv,3,matched text\n'
 		);
 	});
 
@@ -48,7 +48,7 @@ suite('ResultContentCSVModel', () => {
 		model.setGrepConditionText(BASE_DIR, GREP_CONDITION);
 
 		const line = model.getContentInOneLine('c:\\some\\file.csv', '3', 'matched text');
-		assert.strictEqual(line, 'c:\\some\\file.csv,3,matched text');
+		assert.strictEqual(line, 'c:\\some\\file.csv,3,matched text\n');
 	});
 
 });

--- a/src/test/unit/ResultContentTSVModel.test.ts
+++ b/src/test/unit/ResultContentTSVModel.test.ts
@@ -20,14 +20,14 @@ suite('ResultContentTSVModel', () => {
 		const dao = new FakeDao({ outputTitle: true });
 		const model = new ResultContentTSVModel(dao, new ResultFileModel(dao));
 
-		assert.strictEqual(model.ColumnTitle, 'GrepConf\tFilePath\tlineNumber\tTextLine');
+		assert.strictEqual(model.ColumnTitle, 'GrepConf\tFilePath\tlineNumber\tTextLine\n');
 	});
 
 	test('ColumnTitle drops the GrepConf column when outputTitle is off', () => {
 		const dao = new FakeDao({ outputTitle: false });
 		const model = new ResultContentTSVModel(dao, new ResultFileModel(dao));
 
-		assert.strictEqual(model.ColumnTitle, 'FilePath\tlineNumber\tTextLine');
+		assert.strictEqual(model.ColumnTitle, 'FilePath\tlineNumber\tTextLine\n');
 	});
 
 	test('getContentInOneLine embeds the grep condition (" | " joined) into every row when outputTitle is on', () => {
@@ -38,7 +38,7 @@ suite('ResultContentTSVModel', () => {
 		const line = model.getContentInOneLine('c:\\some\\file.tsv', '3', 'matched text');
 		assert.strictEqual(
 			line,
-			'Search Dir: C:\\base | Search Word: lo | RegExpMode: OFF\tc:\\some\\file.tsv\t3\tmatched text'
+			'Search Dir: C:\\base | Search Word: lo | RegExpMode: OFF\tc:\\some\\file.tsv\t3\tmatched text\n'
 		);
 	});
 
@@ -48,7 +48,7 @@ suite('ResultContentTSVModel', () => {
 		model.setGrepConditionText(BASE_DIR, GREP_CONDITION);
 
 		const line = model.getContentInOneLine('c:\\some\\file.tsv', '3', 'matched text');
-		assert.strictEqual(line, 'c:\\some\\file.tsv\t3\tmatched text');
+		assert.strictEqual(line, 'c:\\some\\file.tsv\t3\tmatched text\n');
 	});
 
 });


### PR DESCRIPTION
## Summary
- `ResultFileModel` positions every insert at `Position(document.lineCount, 0)`, which only lands on a fresh line when the previous insert ended with a real line break. txt's `getFormattedContent` already appended one, but csv/tsv's override didn't, so consecutive match rows got pasted together with no separator at all (previously masked by an incidental `\r` left over from CRLF source lines, which older VS Code treated as a soft line break but the current version does not).
- `ResultContentCSVModel.getFormattedContent` now appends `Common.LINE_BREAK`, matching the base/txt behavior. `ResultContentTSVModel`'s now-identical override is removed (inherits the fix from CSV).
- Regenerated the tsv/csv expected fixtures and updated the corresponding unit test expectations for the added trailing newline.
- Also includes a batched-write rewrite of `GrepService`/`ResultFileModel`/`ResultContentModel` (`addLines`/`insertTextBlock`) that writes matches in groups instead of one editor edit per match, and a `getRegExp(true)` fix in `SearchWordConfiguration` so the global-flagged RegExp used for decoration is no longer accidentally cached into the non-global path.

## Known pre-existing issue (not fixed here, flagged for follow-up)
txt/tsv/csv "default mode" tests show a match-count mismatch against stale fixtures, traced to (1) fixtures not reflecting current test-resources/input content and (2) a `_Shift_JIS/grep2File.g2f.txt` fixture that collides by filename with the output file, so it's inconsistently excluded depending on output format.

## Test plan
- [x] `npm run compile` / `npm run lint` — clean
- [x] `npm test` — regexp-mode and json suites pass; default-mode txt/tsv/csv fail only on the known pre-existing match-count issue above, not on row separation
- [x] Verified tsv/csv rows are now properly newline-separated in generated fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)